### PR TITLE
Add gcp-loadbalancer-proxy to m-lab project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+go:
+- '1.11'
+
+# Place the repo at GOPATH/src/${go_import_path} to support PRs from forks.
+go_import_path: github.com/m-lab/gcp-loadbalancer-proxy
+
+before_install:
+- go get github.com/mattn/goveralls
+
+script:
+# Run "unit tests".
+- go test -v -short -covermode=count -coverprofile=merge.cov github.com/m-lab/gcp-loadbalancer-proxy
+
+# Coveralls
+- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
+
+# Verify that the docker image builds.
+- docker build -t gcp-loadbalancer-proxy .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.11 as build
+ADD . /go/src/github.com/stephen-soltesz/gcp-loadbalancer-proxy
+RUN CGO_ENABLED=0 go get -v github.com/stephen-soltesz/gcp-loadbalancer-proxy
+
+# Now copy the built image into the minimal base image
+FROM alpine
+COPY --from=build /go/bin/gcp-loadbalancer-proxy /
+WORKDIR /
+ENTRYPOINT ["/gcp-loadbalancer-proxy"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/gcp-loadbalancer-proxy)](https://goreportcard.com/report/github.com/m-lab/gcp-loadbalancer-proxy) [![Build Status](https://travis-ci.org/m-lab/gcp-loadbalancer-proxy.svg?branch=master)](https://travis-ci.org/m-lab/gcp-loadbalancer-proxy) [![Coverage Status](https://coveralls.io/repos/github/m-lab/gcp-loadbalancer-proxy/badge.svg?branch=master)](https://coveralls.io/github/m-lab/gcp-loadbalancer-proxy?branch=master)
+
 # gcp-loadbalancer-proxy
-Provide an HTTP-to-HTTPS proxy for GCP Loadbalancer Health Checks
+
+gcp-loadbalancer-proxy provides an HTTP-to-insecure-HTTPS proxy.
+
+For example, this can be helpful when deploying GCP LoadBalancer health
+checks, which currently only support HTTP targets.
+
+Default options support use as a proxy for HA Kubernetes master health
+checks.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,74 @@
+// gcp-loadbalancer-proxy provides an HTTP-to-insecure-HTTPS proxy.
+//
+// For example, this can be helpful when deploying GCP LoadBalancer health
+// checks, which currently only support HTTP targets.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/m-lab/go/rtx"
+)
+
+var (
+	rawURL  string
+	rawAddr string
+
+	// Create a ctx & cancel for
+	ctx, cancelCtx = context.WithCancel(context.Background())
+)
+
+func init() {
+	flag.StringVar(&rawURL, "url", "https://localhost:6443",
+		"The base URL to query (insecurely).")
+	flag.StringVar(&rawAddr, "port", ":8080",
+		"Listen on the given address.")
+}
+
+func newReverseProxy(target *url.URL) (*httputil.ReverseProxy, error) {
+	if target.RawQuery != "" || target.Path != "" {
+		return nil, fmt.Errorf("Do not provide target path or queries. " +
+			"All paths and queries are copied from incoming requests.")
+	}
+	director := func(req *http.Request) {
+		// Override the http "Host:" header to specify target.Host.
+		req.Host = target.Host
+		// Override the request scheme and host to connect via TLS.
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+	}
+
+	// Override the default transport settings to support insecure TLS connections.
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	return &httputil.ReverseProxy{
+		Director:  director,
+		Transport: transport,
+	}, nil
+}
+
+func main() {
+	flag.Parse()
+
+	target, err := url.Parse(rawURL)
+	rtx.Must(err, "Failed to parse given url: %s", rawURL)
+
+	reverseProxy, err := newReverseProxy(target)
+	rtx.Must(err, "Failed to create reverse proxy: %s", target)
+
+	http.Handle("/", reverseProxy)
+	go func() {
+		log.Fatal(http.ListenAndServe(rawAddr, nil))
+	}()
+
+	<-ctx.Done()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,122 @@
+// gcp-service-discovery provides an HTTP-to-insecure-HTTPS proxy.
+//
+// For example, this can be helpful for Google LoadBalancer health
+// checkers which only support HTTP health-check targets.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+)
+
+func Test_newReverseProxy(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      *url.URL
+		statusCode  int
+		fileContent string
+		path        string
+		want        *httputil.ReverseProxy
+		wantErr     bool
+		targetPath  string
+	}{
+		{
+			name:        "success",
+			statusCode:  http.StatusOK,
+			path:        "/",
+			fileContent: "ok",
+		},
+		{
+			name:        "success-status-code-propagates",
+			statusCode:  http.StatusNotFound,
+			path:        "/",
+			fileContent: "ok",
+		},
+		{
+			name:        "success-path-propagates",
+			statusCode:  http.StatusOK,
+			path:        "/healthz",
+			fileContent: "ok",
+		},
+		{
+			name:        "success-path-with-query-parameters",
+			statusCode:  http.StatusOK,
+			path:        "/healthz?foo=bar&thing=that",
+			fileContent: "ok",
+		},
+		{
+			name:        "failure-reverse-proxy-returns-error",
+			statusCode:  http.StatusOK,
+			path:        "/",
+			fileContent: "ok",
+			targetPath:  "/bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a tls target server that the reverse proxy will query.
+			tls := httptest.NewTLSServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.statusCode)
+					fmt.Fprint(w, tt.fileContent+r.URL.String())
+				}),
+			)
+			defer tls.Close()
+
+			// Setup the reverse proxy & test server to target the tls test server.
+			u, err := url.Parse(tls.URL + tt.targetPath)
+			rtx.Must(err, "httptest URL could not be parsed: %s", tls.URL)
+			rp, err := newReverseProxy(u)
+			if err != nil {
+				if tt.targetPath != "" {
+					// If the target path is non zero, then we want this to be an error.
+					return
+				} else {
+					t.Errorf("newReverseProxy error = %v, targetPath %v", err, tt.targetPath)
+				}
+			}
+			ts := httptest.NewServer(rp)
+			defer ts.Close()
+
+			// Issue a request to the second test server and verify return values.
+			resp, err := http.Get(ts.URL + tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newReverseProxy request error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if resp.StatusCode != tt.statusCode {
+				t.Errorf("newReverseProxy request StatusCode; got = %v, want %v",
+					resp.StatusCode, tt.statusCode)
+			}
+			b, err := ioutil.ReadAll(resp.Body)
+			rtx.Must(err, "Failed to read response")
+			if string(b) != tt.fileContent+tt.path {
+				t.Errorf("newReverseProxy fileContent; got = %v, want %v",
+					string(b), tt.fileContent+tt.path)
+			}
+
+		})
+	}
+}
+
+func Test_main(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "ok")
+		}),
+	)
+	defer ts.Close()
+	rawURL = ts.URL
+	go func() {
+		http.Get("http://localhost" + rawAddr)
+		cancelCtx()
+	}()
+	main()
+}


### PR DESCRIPTION
This change adds a complete implementation of the gcp-loadbalancer-proxy to support TLS k8s health checks using GCP loadbalancers (http-only).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-loadbalancer-proxy/1)
<!-- Reviewable:end -->
